### PR TITLE
Added campaign field to transactions stream schema

### DIFF
--- a/tap_awin/streams.py
+++ b/tap_awin/streams.py
@@ -69,6 +69,7 @@ class TransactionsStream(AwinStream):
         th.Property("commissionSharingPublisherId", th.IntegerType),
         th.Property("commissionSharingSelectedRatePublisherId", th.IntegerType),
         th.Property("siteName", th.StringType),
+        th.Property("campaign", th.StringType),
         th.Property("commissionStatus", th.StringType),
         th.Property("commissionAmount", th.ObjectType(
             th.Property("amount", th.NumberType),


### PR DESCRIPTION
This addresses issue #2 . It hasn't been tested locally, but seems pretty straightforward.
This tap has been excellent for my use case. Just need to make a small schema tweak or two to access all our data. 