### PR TITLE
Schema tweaks

### DIFF
--- a/tap_awin/streams.py
+++ b/tap_awin/streams.py
@@ -120,10 +120,6 @@ class TransactionsStream(AwinStream):
         )),
         th.Property("transactionParts", th.ArrayType(
             th.ObjectType(
-                th.Property("advertiserCost", th.ObjectType(
-                    th.Property("amount", th.NumberType),
-                    th.Property("currency", th.StringType),
-                )),
                 th.Property("amount", th.NumberType),
                 th.Property("commissionAmount", th.NumberType),
                 th.Property("commissionGroupCode", th.StringType),

--- a/tap_awin/streams.py
+++ b/tap_awin/streams.py
@@ -82,7 +82,12 @@ class TransactionsStream(AwinStream):
         th.Property("ipHash", th.IntegerType),
         th.Property("customerCountry", th.StringType),
         th.Property("clickRefs", th.ObjectType(
-            th.Property("clickRefs", th.StringType),
+            th.Property("clickRef", th.StringType),
+            th.Property("clickRef2", th.StringType),
+            th.Property("clickRef3", th.StringType),
+            th.Property("clickRef4", th.StringType),
+            th.Property("clickRef5", th.StringType),
+            th.Property("clickRef6", th.StringType),
         )),
         th.Property("clickDate", th.DateTimeType),
         th.Property("transactionDate", th.DateTimeType),

--- a/tap_awin/streams.py
+++ b/tap_awin/streams.py
@@ -142,6 +142,17 @@ class TransactionsStream(AwinStream):
             th.Property("amount", th.NumberType),
             th.Property("currency", th.StringType),
         )),
+        th.Property("basketProducts", th.ArrayType(
+            th.ObjectType(
+                th.Property("productId", th.StringType),
+                th.Property("productName", th.StringType),
+                th.Property("unitPrice", th.NumberType),
+                th.Property("quantity", th.IntegerType),
+                th.Property("skuCode", th.StringType),
+                th.Property("commissionGroupCode", th.StringType),
+                th.Property("category", th.StringType),
+            )
+        )),
     ).to_dict()
 
     def get_url_params(


### PR DESCRIPTION
Separated out the `clickRefs` attributes to capture the clickRef2-6 fields.
Removed duplicate `advertiserCost` fields nested under transactionParts, since they're already included in the top level of the schema. Aligning with the API in https://wiki.awin.com/index.php/API_get_transactions_list
Also added the `basketProducts` array to the schema.